### PR TITLE
added ios and other tests

### DIFF
--- a/MainPage.xaml
+++ b/MainPage.xaml
@@ -14,6 +14,9 @@
 
         <Button x:Name="ShowPopupButton2" Text="Show popup 2" Clicked="ShowPopupButton2_Clicked" />
         <Button x:Name="ShowPopupButton3" Text="Show popup 3" Clicked="ShowPopupButton3_Clicked" />
+        <Button x:Name="ShowPopupButton2Workaround" Text="Show popup 2 workaround" Clicked="ShowPopupButton2Workaround_Clicked" />
+        <Button x:Name="ShowPopupButton3Workaround" Text="Show popup 3 workaround" Clicked="ShowPopupButton3Workaround_Clicked" />
+
 
     </VerticalStackLayout>
 

--- a/MainPage.xaml
+++ b/MainPage.xaml
@@ -14,6 +14,7 @@
 
         <Button x:Name="ShowPopupButton2" Text="Show popup 2" Clicked="ShowPopupButton2_Clicked" />
         <Button x:Name="ShowPopupButton3" Text="Show popup 3" Clicked="ShowPopupButton3_Clicked" />
+        <Button x:Name="ShowPopupButtonWorkaround" Text="Show popup workaround" Clicked="ShowPopupButtonWorkaround_Clicked" />
         <Button x:Name="ShowPopupButton2Workaround" Text="Show popup 2 workaround" Clicked="ShowPopupButton2Workaround_Clicked" />
         <Button x:Name="ShowPopupButton3Workaround" Text="Show popup 3 workaround" Clicked="ShowPopupButton3Workaround_Clicked" />
 

--- a/MainPage.xaml
+++ b/MainPage.xaml
@@ -10,7 +10,12 @@
 
             <Button x:Name="ShowPopupButton" Text="Show popup" Clicked="ShowPopupButton_Clicked" />
 
-        </VerticalStackLayout>
+        <Button x:Name="ShowPopupButton1" Text="Show popup 1" Clicked="ShowPopupButton1_Clicked" />
+
+        <Button x:Name="ShowPopupButton2" Text="Show popup 2" Clicked="ShowPopupButton2_Clicked" />
+        <Button x:Name="ShowPopupButton3" Text="Show popup 3" Clicked="ShowPopupButton3_Clicked" />
+
+    </VerticalStackLayout>
 
 
 </ContentPage>

--- a/MainPage.xaml.cs
+++ b/MainPage.xaml.cs
@@ -19,6 +19,33 @@ namespace MauiPopupTest
             await popup.Load();
             
         }
+
+        async void ShowPopupButton1_Clicked(object sender, EventArgs e)
+        {
+            TestPopup1 popup = new TestPopup1();
+            Application.Current!.MainPage!.ShowPopup(popup);
+
+            await popup.Load();
+
+        }
+
+        async void ShowPopupButton2_Clicked(object sender, EventArgs e)
+        {
+            TestPopup2 popup = new TestPopup2();
+            Application.Current!.MainPage!.ShowPopup(popup);
+
+            await popup.Load();
+
+        }
+
+        async void ShowPopupButton3_Clicked(object sender, EventArgs e)
+        {
+            TestPopup3 popup = new TestPopup3();
+            Application.Current!.MainPage!.ShowPopup(popup);
+
+            await popup.Load();
+
+        }
     }
 
 }

--- a/MainPage.xaml.cs
+++ b/MainPage.xaml.cs
@@ -46,6 +46,22 @@ namespace MauiPopupTest
             await popup.Load();
 
         }
+
+        private async void ShowPopupButton2Workaround_Clicked(object sender, EventArgs e)
+        {
+            TestPopup2workaround popup = new TestPopup2workaround();
+            Application.Current!.MainPage!.ShowPopup(popup);
+
+            await popup.Load();
+        }
+
+        private async void ShowPopupButton3Workaround_Clicked(object sender, EventArgs e)
+        {
+            TestPopup3workaround popup = new TestPopup3workaround();
+            Application.Current!.MainPage!.ShowPopup(popup);
+
+            await popup.Load();
+        }
     }
 
 }

--- a/MainPage.xaml.cs
+++ b/MainPage.xaml.cs
@@ -47,6 +47,15 @@ namespace MauiPopupTest
 
         }
 
+        private async void ShowPopupButtonWorkaround_Clicked(object sender, EventArgs e)
+        {
+            TestPopupWorkaround popup = new TestPopupWorkaround();
+            Application.Current!.MainPage!.ShowPopup(popup);
+
+            await popup.Load();
+        }
+
+
         private async void ShowPopupButton2Workaround_Clicked(object sender, EventArgs e)
         {
             TestPopup2workaround popup = new TestPopup2workaround();

--- a/MauiPopupTest.csproj
+++ b/MauiPopupTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-android</TargetFrameworks>
+		<TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
 
@@ -29,6 +29,8 @@
 		<ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
 		<ApplicationVersion>1</ApplicationVersion>
 
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">13.1</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
 	</PropertyGroup>
 
@@ -62,12 +64,30 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <Compile Update="TestPopup3.xaml.cs">
+	    <DependentUpon>TestPopup3.xaml</DependentUpon>
+	  </Compile>
+	  <Compile Update="TestPopup2.xaml.cs">
+	    <DependentUpon>TestPopup2.xaml</DependentUpon>
+	  </Compile>
+	  <Compile Update="TestPopup1.xaml.cs">
+	    <DependentUpon>TestPopup1.xaml</DependentUpon>
+	  </Compile>
 	  <Compile Update="TestPopup.xaml.cs">
 	    <DependentUpon>TestPopup.xaml</DependentUpon>
 	  </Compile>
 	</ItemGroup>
 
 	<ItemGroup>
+	  <MauiXaml Update="TestPopup3.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
+	  <MauiXaml Update="TestPopup2.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
+	  <MauiXaml Update="TestPopup1.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
 	  <MauiXaml Update="TestPopup.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>

--- a/MauiPopupTest.csproj
+++ b/MauiPopupTest.csproj
@@ -64,6 +64,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <Compile Update="TestPopup2workaround.xaml.cs">
+	    <DependentUpon>TestPopup2workaround.xaml</DependentUpon>
+	  </Compile>
+	  <Compile Update="TestPopup3workaround.xaml.cs">
+	    <DependentUpon>TestPopup3workaround.xaml</DependentUpon>
+	  </Compile>
 	  <Compile Update="TestPopup3.xaml.cs">
 	    <DependentUpon>TestPopup3.xaml</DependentUpon>
 	  </Compile>
@@ -79,6 +85,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <MauiXaml Update="TestPopup2workaround.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
+	  <MauiXaml Update="TestPopup3workaround.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
 	  <MauiXaml Update="TestPopup3.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>

--- a/MauiPopupTest.csproj
+++ b/MauiPopupTest.csproj
@@ -64,6 +64,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <Compile Update="TestPopupWorkaround.xaml.cs">
+	    <DependentUpon>TestPopupWorkaround.xaml</DependentUpon>
+	  </Compile>
 	  <Compile Update="TestPopup2workaround.xaml.cs">
 	    <DependentUpon>TestPopup2workaround.xaml</DependentUpon>
 	  </Compile>
@@ -85,6 +88,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <MauiXaml Update="TestPopupWorkaround.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
 	  <MauiXaml Update="TestPopup2workaround.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>

--- a/Platforms/iOS/AppDelegate.cs
+++ b/Platforms/iOS/AppDelegate.cs
@@ -1,0 +1,10 @@
+﻿using Foundation;
+
+namespace MauiPopupTest
+{
+    [Register("AppDelegate")]
+    public class AppDelegate : MauiUIApplicationDelegate
+    {
+        protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+    }
+}

--- a/Platforms/iOS/Info.plist
+++ b/Platforms/iOS/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+		<integer>2</integer>
+	</array>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>arm64</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>XSAppIconAssets</key>
+	<string>Assets.xcassets/appicon.appiconset</string>
+</dict>
+</plist>

--- a/Platforms/iOS/Program.cs
+++ b/Platforms/iOS/Program.cs
@@ -1,0 +1,16 @@
+﻿using ObjCRuntime;
+using UIKit;
+
+namespace MauiPopupTest
+{
+    public class Program
+    {
+        // This is the main entry point of the application.
+        static void Main(string[] args)
+        {
+            // if you want to use a different Application Delegate class from "AppDelegate"
+            // you can specify it here.
+            UIApplication.Main(args, null, typeof(AppDelegate));
+        }
+    }
+}

--- a/TestPopup1.xaml
+++ b/TestPopup1.xaml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<toolkit:Popup
+    x:Class="MauiPopupTest.TestPopup1"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MauiPopupTest"
+    xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+    Color="Transparent">
+
+    <Border BackgroundColor="Blue" x:Name="RootBorder" Padding="20">
+        <Border.StrokeShape>
+            <RoundRectangle CornerRadius="12" />
+        </Border.StrokeShape>
+        <StackLayout Orientation="Vertical" BackgroundColor="Pink">
+            <ActivityIndicator x:Name="LoadingActivityIndicator" WidthRequest="50" HeightRequest="50" HorizontalOptions="Center" IsRunning="true" IsVisible="true" />
+            <Label TextColor="Green" Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi lobortis leo id tortor dignissim, eu tincidunt neque viverra. Sed rutrum porttitor magna id dictum. Aliquam tincidunt vel neque non euismod. Vivamus elementum ante felis, in tempus tortor finibus ut. Nulla nulla massa, sollicitudin imperdiet nisl ac, consectetur varius dui. Suspendisse congue neque a pellentesque euismod. Nam non ultricies mi. Aenean sagittis risus nibh, ut iaculis ipsum iaculis dictum." LineBreakMode="WordWrap" />
+
+            <BoxView HeightRequest="200" WidthRequest="150" BackgroundColor="Red"/>
+            
+            <Label x:Name="LabelContent" LineBreakMode="WordWrap" />
+        </StackLayout>
+    </Border>
+
+
+
+</toolkit:Popup>

--- a/TestPopup1.xaml.cs
+++ b/TestPopup1.xaml.cs
@@ -1,0 +1,23 @@
+﻿using CommunityToolkit.Maui.Views;
+
+namespace MauiPopupTest;
+
+public partial class TestPopup1 : Popup
+{
+    public TestPopup1()
+    {
+        InitializeComponent();
+        RootBorder.WidthRequest = 0.9 * DeviceDisplay.Current.GetWidthDpi();
+    }
+
+    public async Task Load()
+    {
+        await Task.Delay(1000);
+        
+        LoadingActivityIndicator.IsRunning = false;
+        LoadingActivityIndicator.IsVisible = false;
+
+        LabelContent.Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi lobortis leo id tortor dignissim, eu tincidunt neque viverra. Sed rutrum porttitor magna id dictum. Aliquam tincidunt vel neque non euismod. Vivamus elementum ante felis, in tempus tortor finibus ut. Nulla nulla massa, sollicitudin imperdiet nisl ac, consectetur varius dui. Suspendisse congue neque a pellentesque euismod. Nam non ultricies mi. Aenean sagittis risus nibh, ut iaculis ipsum iaculis dictum.";
+    }
+}
+

--- a/TestPopup2.xaml
+++ b/TestPopup2.xaml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<toolkit:Popup
+    x:Class="MauiPopupTest.TestPopup2"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MauiPopupTest"
+    xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+    Color="Transparent">
+
+    <Border BackgroundColor="Blue" x:Name="RootBorder" Padding="20">
+        <Border.StrokeShape>
+            <RoundRectangle CornerRadius="12" />
+        </Border.StrokeShape>
+        <StackLayout Orientation="Vertical" BackgroundColor="Pink">
+            <ActivityIndicator x:Name="LoadingActivityIndicator" WidthRequest="50" HeightRequest="50" HorizontalOptions="Center" IsRunning="true" IsVisible="true" />
+
+            <BoxView HeightRequest="200" WidthRequest="150" BackgroundColor="Red"/>
+            
+            <Label x:Name="LabelContent" LineBreakMode="WordWrap" />
+        </StackLayout>
+    </Border>
+
+
+
+</toolkit:Popup>

--- a/TestPopup2.xaml.cs
+++ b/TestPopup2.xaml.cs
@@ -1,0 +1,23 @@
+﻿using CommunityToolkit.Maui.Views;
+
+namespace MauiPopupTest;
+
+public partial class TestPopup2 : Popup
+{
+    public TestPopup2()
+    {
+        InitializeComponent();
+        RootBorder.WidthRequest = 0.9 * DeviceDisplay.Current.GetWidthDpi();
+    }
+
+    public async Task Load()
+    {
+        await Task.Delay(1000);
+        
+        LoadingActivityIndicator.IsRunning = false;
+        LoadingActivityIndicator.IsVisible = false;
+
+        LabelContent.Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi lobortis leo id tortor dignissim, eu tincidunt neque viverra. Sed rutrum porttitor magna id dictum. Aliquam tincidunt vel neque non euismod. Vivamus elementum ante felis, in tempus tortor finibus ut. Nulla nulla massa, sollicitudin imperdiet nisl ac, consectetur varius dui. Suspendisse congue neque a pellentesque euismod. Nam non ultricies mi. Aenean sagittis risus nibh, ut iaculis ipsum iaculis dictum.";
+    }
+}
+

--- a/TestPopup2workaround.xaml
+++ b/TestPopup2workaround.xaml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<toolkit:Popup
+    x:Class="MauiPopupTest.TestPopup2workaround"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MauiPopupTest"
+    xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+    Color="Transparent">
+
+    <Grid ColumnDefinitions="Auto" RowDefinitions="Auto">
+        <Border
+            x:Name="RootBorder"
+            Padding="20"
+            BackgroundColor="Blue"
+            SizeChanged="RootBorder_SizeChanged">
+            <Border.StrokeShape>
+                <RoundRectangle CornerRadius="12" />
+            </Border.StrokeShape>
+            <StackLayout BackgroundColor="Pink" Orientation="Vertical">
+                <ActivityIndicator
+                    x:Name="LoadingActivityIndicator"
+                    HeightRequest="50"
+                    HorizontalOptions="Center"
+                    IsRunning="true"
+                    IsVisible="true"
+                    WidthRequest="50" />
+
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="200"
+                    WidthRequest="150" />
+
+                <Label x:Name="LabelContent" LineBreakMode="WordWrap" />
+            </StackLayout>
+        </Border>
+    </Grid>
+
+
+</toolkit:Popup>

--- a/TestPopup2workaround.xaml.cs
+++ b/TestPopup2workaround.xaml.cs
@@ -1,0 +1,28 @@
+﻿using CommunityToolkit.Maui.Views;
+
+namespace MauiPopupTest;
+
+public partial class TestPopup2workaround : Popup
+{
+    public TestPopup2workaround()
+    {
+        InitializeComponent();
+        RootBorder.WidthRequest = 0.9 * DeviceDisplay.Current.GetWidthDpi();
+    }
+
+    public async Task Load()
+    {
+        await Task.Delay(1000);
+        
+        LoadingActivityIndicator.IsRunning = false;
+        LoadingActivityIndicator.IsVisible = false;
+
+        LabelContent.Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi lobortis leo id tortor dignissim, eu tincidunt neque viverra. Sed rutrum porttitor magna id dictum. Aliquam tincidunt vel neque non euismod. Vivamus elementum ante felis, in tempus tortor finibus ut. Nulla nulla massa, sollicitudin imperdiet nisl ac, consectetur varius dui. Suspendisse congue neque a pellentesque euismod. Nam non ultricies mi. Aenean sagittis risus nibh, ut iaculis ipsum iaculis dictum.";
+    }
+
+    private void RootBorder_SizeChanged(object sender, EventArgs e)
+    {
+        this.Size = new Size(this.RootBorder.Width, this.RootBorder.Height);
+    }
+}
+

--- a/TestPopup3.xaml
+++ b/TestPopup3.xaml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<toolkit:Popup
+    x:Class="MauiPopupTest.TestPopup3"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MauiPopupTest"
+    xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+    Color="Transparent">
+
+    <Grid BackgroundColor="BlanchedAlmond" RowDefinitions="Auto">
+        <Border
+            x:Name="RootBorder"
+            Padding="20"
+            BackgroundColor="White">
+            <Border.StrokeShape>
+                <RoundRectangle CornerRadius="12" />
+            </Border.StrokeShape>
+            <StackLayout Orientation="Vertical">
+                <ActivityIndicator
+                    x:Name="LoadingActivityIndicator"
+                    HeightRequest="50"
+                    HorizontalOptions="Center"
+                    IsRunning="true"
+                    IsVisible="true"
+                    WidthRequest="50" />
+                <Label x:Name="LabelContent" LineBreakMode="WordWrap" />
+            </StackLayout>
+        </Border>
+    </Grid>
+
+
+</toolkit:Popup>

--- a/TestPopup3.xaml.cs
+++ b/TestPopup3.xaml.cs
@@ -1,0 +1,23 @@
+﻿using CommunityToolkit.Maui.Views;
+
+namespace MauiPopupTest;
+
+public partial class TestPopup3 : Popup
+{
+    public TestPopup3()
+    {
+        InitializeComponent();
+        RootBorder.WidthRequest = 0.9 * DeviceDisplay.Current.GetWidthDpi();
+    }
+
+    public async Task Load()
+    {
+        await Task.Delay(1000);
+        
+        LoadingActivityIndicator.IsRunning = false;
+        LoadingActivityIndicator.IsVisible = false;
+
+        LabelContent.Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi lobortis leo id tortor dignissim, eu tincidunt neque viverra. Sed rutrum porttitor magna id dictum. Aliquam tincidunt vel neque non euismod. Vivamus elementum ante felis, in tempus tortor finibus ut. Nulla nulla massa, sollicitudin imperdiet nisl ac, consectetur varius dui. Suspendisse congue neque a pellentesque euismod. Nam non ultricies mi. Aenean sagittis risus nibh, ut iaculis ipsum iaculis dictum.";
+    }
+}
+

--- a/TestPopup3workaround.xaml
+++ b/TestPopup3workaround.xaml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<toolkit:Popup
+    x:Class="MauiPopupTest.TestPopup3workaround"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MauiPopupTest"
+    xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+    Color="Transparent">
+
+    <Grid BackgroundColor="BlanchedAlmond" RowDefinitions="Auto">
+        <Border
+            x:Name="RootBorder"
+            Padding="20"
+            SizeChanged="RootBorder_SizeChanged"           
+            BackgroundColor="White">
+            <Border.StrokeShape>
+                <RoundRectangle CornerRadius="12" />
+            </Border.StrokeShape>
+            <StackLayout Orientation="Vertical">
+                <ActivityIndicator
+                    x:Name="LoadingActivityIndicator"
+                    HeightRequest="50"
+                    HorizontalOptions="Center"
+                    IsRunning="true"
+                    IsVisible="true"
+                    WidthRequest="50" />
+                <Label x:Name="LabelContent" LineBreakMode="WordWrap" BackgroundColor="Red" />
+            </StackLayout>
+        </Border>
+    </Grid>
+
+
+</toolkit:Popup>

--- a/TestPopup3workaround.xaml.cs
+++ b/TestPopup3workaround.xaml.cs
@@ -1,0 +1,28 @@
+﻿using CommunityToolkit.Maui.Views;
+
+namespace MauiPopupTest;
+
+public partial class TestPopup3workaround : Popup
+{
+    public TestPopup3workaround()
+    {
+        InitializeComponent();
+        RootBorder.WidthRequest = 0.9 * DeviceDisplay.Current.GetWidthDpi();
+    }
+
+    public async Task Load()
+    {
+        await Task.Delay(1000);
+        
+        LoadingActivityIndicator.IsRunning = false;
+        LoadingActivityIndicator.IsVisible = false;
+
+        LabelContent.Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi lobortis leo id tortor dignissim, eu tincidunt neque viverra. Sed rutrum porttitor magna id dictum. Aliquam tincidunt vel neque non euismod. Vivamus elementum ante felis, in tempus tortor finibus ut. Nulla nulla massa, sollicitudin imperdiet nisl ac, consectetur varius dui. Suspendisse congue neque a pellentesque euismod. Nam non ultricies mi. Aenean sagittis risus nibh, ut iaculis ipsum iaculis dictum.";
+    }
+
+    private void RootBorder_SizeChanged(object sender, EventArgs e)
+    {
+        this.Size = new Size(this.RootBorder.Width, this.RootBorder.Height);
+    }
+}
+

--- a/TestPopupWorkaround.xaml
+++ b/TestPopupWorkaround.xaml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<toolkit:Popup
+    x:Class="MauiPopupTest.TestPopupWorkaround"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:MauiPopupTest"
+    xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+    Color="Transparent">
+
+    <Grid ColumnDefinitions="Auto" RowDefinitions="Auto">
+        <Border
+            x:Name="RootBorder"
+            Padding="20"
+            BackgroundColor="White"
+            SizeChanged="RootBorder_SizeChanged">
+            <Border.StrokeShape>
+                <RoundRectangle CornerRadius="12" />
+            </Border.StrokeShape>
+            <StackLayout Orientation="Vertical">
+                <ActivityIndicator
+                    x:Name="LoadingActivityIndicator"
+                    HeightRequest="50"
+                    HorizontalOptions="Center"
+                    IsRunning="true"
+                    IsVisible="true"
+                    WidthRequest="50" />
+                <Label x:Name="LabelContent" LineBreakMode="WordWrap" />
+            </StackLayout>
+        </Border>
+
+    </Grid>
+
+</toolkit:Popup>

--- a/TestPopupWorkaround.xaml.cs
+++ b/TestPopupWorkaround.xaml.cs
@@ -1,0 +1,27 @@
+﻿using CommunityToolkit.Maui.Views;
+
+namespace MauiPopupTest;
+
+public partial class TestPopupWorkaround : Popup
+{
+    public TestPopupWorkaround()
+    {
+        InitializeComponent();
+        RootBorder.WidthRequest = 0.9 * DeviceDisplay.Current.GetWidthDpi();
+    }
+
+    public async Task Load()
+    {
+        await Task.Delay(1000);
+        
+        LoadingActivityIndicator.IsRunning = false;
+        LoadingActivityIndicator.IsVisible = false;
+
+        LabelContent.Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi lobortis leo id tortor dignissim, eu tincidunt neque viverra. Sed rutrum porttitor magna id dictum. Aliquam tincidunt vel neque non euismod. Vivamus elementum ante felis, in tempus tortor finibus ut. Nulla nulla massa, sollicitudin imperdiet nisl ac, consectetur varius dui. Suspendisse congue neque a pellentesque euismod. Nam non ultricies mi. Aenean sagittis risus nibh, ut iaculis ipsum iaculis dictum.";
+    }
+
+    private void RootBorder_SizeChanged(object sender, EventArgs e)
+    {
+        this.Size = new Size(this.RootBorder.Width, this.RootBorder.Height);
+    }
+}


### PR DESCRIPTION
Added more tests and project for iOS. There are different behaviors between iOS and Android. I'll try to list them.
- Popup is the initial popup
- Popup1 displays a "lorem ipsum" string above a red box, and then below the red box another "lorem ipsum" string
- Popup2 displays a red box, and then under the red box a "lorem ipsum" string
- Popup3 like the original popup but with an external grid

on Android it seems that the content resizes correctly but the size of the popup does not change. In Popup3, with the external grid, it seems that the popup also resizes but the string is not handled correctly.

on iOS, content resizes but is cropped. The popup does not change (it has the size of the initially loaded contours). In Popup3, the content resizes but not the popup.
In popup2, if you press to the left or right of the red box, the popup closes. it's as if the outside of the popup were pressed (this is also the case in the original popup, and in popup 3 if you press on the lower half of the popup). In popup1 it seems that this tap problem does not exist.

In conclusion, it seems that the popup only works correctly if the controls are all visible when the popup loads.